### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fpezcara/book-tracker-api/security/code-scanning/1](https://github.com/fpezcara/book-tracker-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's operations, the minimal required permission is `contents: read`, as the workflow only reads repository contents and does not perform any write operations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
