### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pact_tests.yml
+++ b/.github/workflows/pact_tests.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   verify-pact:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fpezcara/book-tracker-api/security/code-scanning/3](https://github.com/fpezcara/book-tracker-api/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, it primarily requires `contents: read` to access repository contents and `packages: read` to download the pact file from a release. No write permissions are necessary.

The `permissions` block will be added at the root level, applying to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
