### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   install:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fpezcara/book-tracker-api/security/code-scanning/4](https://github.com/fpezcara/book-tracker-api/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow does not appear to require write permissions, we will set the permissions to `contents: read` at the root level. This will apply the minimal required permissions to all jobs in the workflow. If any job requires additional permissions in the future, they can be specified individually within that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
