### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/fpezcara/book-tracker-api/security/code-scanning/5](https://github.com/fpezcara/book-tracker-api/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the minimal permissions required for the workflow to function. Since the workflow only checks out code, sets up Ruby, installs dependencies, and runs a linter, it likely only needs `contents: read` permissions. This ensures the workflow cannot perform unintended write actions on the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
